### PR TITLE
Disable Hotjar for production environment.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -101,7 +101,7 @@ document.zendeskLang = '{{ site.lang }}';
 	<!-- ▼ Hotjar ▼ -->
 		{% assign hotjar_id              = site.hotjar_id | strip %}
 		{% assign hotjar_snippet_version = site.hotjar_snippet_version | strip %}
-		{% if hotjar_id != empty and hotjar_snippet_version != empty %}
+		{% if jekyll.environment == 'production' and hotjar_id != empty and hotjar_snippet_version != empty %}
 
 			<script>
 				(function(h,o,t,j,a,r){


### PR DESCRIPTION
Since we're doing a lot of testing in UAT, we need to disable Hotjar since it takes too long time to load.